### PR TITLE
Support adding tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,18 +10,27 @@ npm install loopback-component-mailchimp --save
 
 ## 2. Configuration
 
-component-config.json
+Add the following to component-config.json:
 
     {
         "loopback-component-mailchimp": {
-            "connector": "loopback-connector-mailgun",
-            "apikey": "[your api key here]",
+            "apiKey": "[your api key here]",
             "defaultListId": "[a default listId]",
+            "updateIfExists": true,
             "defaults": {
               "double_optin" : true
             }
         }
     }
+
+### Config Properties
+
+| Property | Description |
+| ----------- | ----------- |
+| apiKey | MailChimp API key (required) |
+| defaultListId | The ID of the destination list to subscribe/unsubscribes users to/from, if unspecified in calls to subscribe/unsubscribe (optional)       |
+| updateIfExists | Whether to update users if they already exist in the list (optional, defaults to false)       |
+| defaults | Optional parameters to pass with subscribe (optional); supported properties are `double_optin` (defaults to `false`)
 
 ## 3. Use
 
@@ -36,7 +45,7 @@ Simple subscribe member. Returns a Promise
         }
     }
 
-    app.MailChimp.subscribe(user, defaultListId)
+    app.MailChimp.subscribe(user, listId)
         .then(function (res) {
             console.log('Result :', res);
         })
@@ -50,21 +59,7 @@ Simple unsubscribe member. Returns a Promise
         email: 'user@email.com'
     }
 
-    app.MailChimp.unsubscribe(user, defaultListId)
-        .then(function (res) {
-            console.log('Result :', res);
-        })
-        .catch(function (err) {
-            console.log('Error : ', err);
-        });
-
-Simple unsubscribe member. Returns a Promise
-
-    var user = {
-        email: 'user@email.com'
-    }
-
-    app.MailChimp.delete(user, defaultListId)
+    app.MailChimp.unsubscribe(user, listId)
         .then(function (res) {
             console.log('Result :', res);
         })

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add the following to component-config.json:
             }
         }
     }
-
+    
 ### Config Properties
 
 | Property | Description |
@@ -30,17 +30,18 @@ Add the following to component-config.json:
 | apiKey | MailChimp API key (required) |
 | defaultListId | The ID of the destination list to subscribe/unsubscribes users to/from, if unspecified in calls to subscribe/unsubscribe (optional)       |
 | updateIfExists | Whether to update users if they already exist in the list (optional, defaults to false)       |
-| defaults | Optional parameters to pass with subscribe (optional); supported properties are `double_optin` (defaults to `false`)
+| defaults | Optional parameters to pass with subscribe; supported properties are `double_optin` (boolean, defaults to `false`) and `tags` (array, defaults to `null`)
 
 ## 3. Use
 
-Simple subscribe member. Returns a Promise
+Subscribe a member. Required properties are `email`, `firstName` and `lastName`. Optional properties are `tags` and `merge_fields`. Returns a Promise:
 
     var user = {
         email: 'user@email.com',
         firstName: 'A name',
         lastName: 'A surname',
-        merge_vars: {
+        tags: ['[a tag]'],
+        merge_fields: {
             optin_ip: '192.168.0.1'
         }
     }
@@ -53,13 +54,31 @@ Simple subscribe member. Returns a Promise
             console.log('Error : ', err);
         });
 
-Simple unsubscribe member. Returns a Promise
+Simple unsubscribe member. Returns a Promise:
 
     var user = {
         email: 'user@email.com'
     }
 
     app.MailChimp.unsubscribe(user, listId)
+        .then(function (res) {
+            console.log('Result :', res);
+        })
+        .catch(function (err) {
+            console.log('Error : ', err);
+        });
+
+Add tags for a subscribed member. Returns a Promise:
+
+    var user = {
+        email: 'user@email.com'
+    }
+    
+    var tags = {
+        'user'
+    }
+
+    app.MailChimp.addTags(user, tags, listId)
         .then(function (res) {
             console.log('Result :', res);
         })

--- a/lib/mailchimp.js
+++ b/lib/mailchimp.js
@@ -4,10 +4,10 @@ var Mailchimp = require('mailchimp-api-v3'),
 	maxmind = require('maxmind');
 md5 = require("md5");
 
-module.exports = function (App, defaults) {
+module.exports = function (App, options) {
 	var Chimp = {};
 
-	Chimp.MailChimp = new Mailchimp(defaults.apikey);
+	Chimp.MailChimp = new Mailchimp(options.apiKey);
 
 	Chimp.subscribe = function (user, listId) {
 		var _this = this;
@@ -16,19 +16,19 @@ module.exports = function (App, defaults) {
 				user.merge_fields = {};
 			}
 
-			var settings = defaults,
-				subscriber = {
+			var subscriber = {
 					email_address: user.email,
-					double_optin: defaults.double_optin || false,
+					double_optin: (options.defaults && options.defaults.double_optin) || false,
 					status: 'subscribed',
 					timestamp_opt: new Date().toISOString().replace('T', ' ').replace(/\..*$/g, ''),
-					list_id: listId || defaults.defaultListId,
+					list_id: listId || options.defaultListId,
 					merge_fields: {
 						EMAIL: user.email,
 						FNAME: user.firstName || null,
 						LNAME: user.lastName || null
 					}
-				};
+				},
+				updateExistingSubscribers = options.updateIfExists || false;
 
 			if (user.ip) {
 				subscriber.ip_opt = user.ip;
@@ -38,15 +38,19 @@ module.exports = function (App, defaults) {
 			subscriber.merge_fields = lo.merge(subscriber.merge_fields, user.merge_fields);
 
 			_this.MailChimp.request({
-				method: 'POST',
-				path: '/lists/{list_id}/members',
+				method: updateExistingSubscribers ? 'PUT' : 'POST',
+				path: updateExistingSubscribers ? 
+					'/lists/{list_id}/members/{subscriber_hash}' : 
+					'/lists/{list_id}/members',
 				path_params: {
-					list_id: listId || defaults.defaultListId
+					list_id: listId || options.defaultListId,
+					subscriber_hash: md5(user.email.toLowerCase()),
 				},
 				body: subscriber,
 				params: {}
 			}, function (err, response) {
 				if (err) {
+
 					return reject(err);
 				}
 
@@ -66,7 +70,7 @@ module.exports = function (App, defaults) {
 				method: 'PATCH',
 				path: '/lists/{list_id}/members/{member_id}',
 				path_params: {
-					list_id: listId || defaults.defaultListId,
+					list_id: listId || options.defaultListId,
 					member_id: md5(user.email.toLowerCase())
 				},
 				body: {
@@ -94,7 +98,7 @@ module.exports = function (App, defaults) {
 				method: 'DELETE',
 				path: '/lists/{list_id}/members/{member_id}',
 				path_params: {
-					list_id: listId || defaults.defaultListId,
+					list_id: listId || options.defaultListId,
 					member_id: md5(user.email.toLowerCase())
 				},
 				params: {}

--- a/lib/mailchimp.js
+++ b/lib/mailchimp.js
@@ -1,13 +1,42 @@
 var Mailchimp = require('mailchimp-api-v3'),
 	Promise = require('bluebird'),
 	lo = require('lodash'),
-	maxmind = require('maxmind');
-md5 = require("md5");
+	maxmind = require('maxmind'),
+	md5 = require('md5');
 
 module.exports = function (App, options) {
 	var Chimp = {};
 
 	Chimp.MailChimp = new Mailchimp(options.apiKey);
+
+	//	https://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/tags/
+	Chimp.addTags = function(user, tags, listId) {
+		var _this = this;
+		return new Promise(function(resolve,reject) {
+
+			if( !listId ) {
+				listId = options.defaultListId;
+			}
+
+			//	add tags to subscriber in expected format
+			let body = {
+				tags: tags.map(tag => ({name:tag,status:'active'})),
+			}
+
+			_this.MailChimp.request({
+				method: 'POST',
+				path: '/lists/{list_id}/members/{subscriber_hash}/tags',
+				path_params: {
+					list_id: listId,
+					subscriber_hash: md5(user.email.toLowerCase()),
+				},
+				body: body,
+				params: {}
+			})
+			.then( resolve )
+			.catch( reject );
+		})
+	}
 
 	Chimp.subscribe = function (user, listId) {
 		var _this = this;
@@ -16,19 +45,28 @@ module.exports = function (App, options) {
 				user.merge_fields = {};
 			}
 
+			if (!user.tags) {
+				user.tags = [];
+			}
+
+			if( !listId ) {
+				listId = options.defaultListId;
+			}
+
 			var subscriber = {
 					email_address: user.email,
 					double_optin: (options.defaults && options.defaults.double_optin) || false,
 					status: 'subscribed',
 					timestamp_opt: new Date().toISOString().replace('T', ' ').replace(/\..*$/g, ''),
-					list_id: listId || options.defaultListId,
+					list_id: listId,
 					merge_fields: {
 						EMAIL: user.email,
 						FNAME: user.firstName || null,
 						LNAME: user.lastName || null
 					}
 				},
-				updateExistingSubscribers = options.updateIfExists || false;
+				updateExistingSubscribers = options.updateIfExists || false,
+				subscribeResponse = null;
 
 			if (user.ip) {
 				subscriber.ip_opt = user.ip;
@@ -36,6 +74,9 @@ module.exports = function (App, options) {
 			}
 
 			subscriber.merge_fields = lo.merge(subscriber.merge_fields, user.merge_fields);
+			
+			let tags = ((options.defaults && options.defaults.tags) || [])
+				.concat(user.tags || []);
 
 			_this.MailChimp.request({
 				method: updateExistingSubscribers ? 'PUT' : 'POST',
@@ -43,19 +84,20 @@ module.exports = function (App, options) {
 					'/lists/{list_id}/members/{subscriber_hash}' : 
 					'/lists/{list_id}/members',
 				path_params: {
-					list_id: listId || options.defaultListId,
+					list_id: listId,
 					subscriber_hash: md5(user.email.toLowerCase()),
 				},
 				body: subscriber,
 				params: {}
-			}, function (err, response) {
-				if (err) {
-
-					return reject(err);
-				}
-
-				resolve(response);
-			});
+			})
+			.then( response => {
+				subscribeResponse = response;
+				return (tags && tags.length) ? 
+					_this.addTags(user,tags,listId) : 
+					Promise.resolve();
+			})
+			.then( () => resolve(subscribeResponse) )
+			.catch( reject );
 		});
 	};
 


### PR DESCRIPTION
The main addition in this PR is the addition of an `addTags` method to the API, which can be called independently and will also be called in `subscribe` if any tags have been specified in the config defaults or with the user argument.

I've also added an `updateIfExsits` config property, which will optionally update the user if they already exist in the destination list when calling `subscribe`.

A few other changes:

- Removed `connector` property from config (it wasn't doing anything to my knowledge)
- Updated README w/ basic explanation of properties